### PR TITLE
Add VSCode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Local Server",
+            "type": "python",
+            "request": "launch",
+            "module": "http.server",
+            "args": ["8000"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add a VSCode launch configuration to run a simple HTTP server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685233c81e648327bc0e9d60d3b03a77