### PR TITLE
Update Appwrite CDN version

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { Client, Account, Databases, Storage, ID, Query } from 'https://cdn.jsdelivr.net/npm/appwrite@13.0.1/+esm';
+import { Client, Account, Databases, Storage, ID, Query } from 'https://cdn.jsdelivr.net/npm/appwrite@18.1.1/+esm';
 import dotenv from 'https://cdn.jsdelivr.net/npm/dotenv@16.3.1/+esm';
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- use Appwrite SDK 18.1.1 from jsDelivr CDN

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68523926dd3c8327919920a4c51f3672