### PR TITLE
Fix Appwrite CDN issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
-import { Client, Account, Databases, Storage, ID, Query } from 'https://cdn.jsdelivr.net/npm/appwrite@18.1.1/+esm';
+// Use Appwrite SDK installed via npm to avoid CDN-related issues.
+import { Client, Account, Databases, Storage, ID, Query } from './node_modules/appwrite/dist/esm/sdk.js';
 import env from './env.js';
 
 const client = new Client()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "yugiohcardexchange",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "appwrite": "^18.1.1"
+      },
       "devDependencies": {
         "http-server": "^14.1.1"
       }
@@ -27,6 +30,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/appwrite": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/appwrite/-/appwrite-18.1.1.tgz",
+      "integrity": "sha512-krwHjuwJcF+9Ig2+nqOEKMA/5kPIFhwwZsaLc7Gb8y2oP6EnG4ZMRPeHTFscdevOtVQj2Ax92cYYWAEvzlrc7A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/async": {
       "version": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "type": "commonjs",
   "devDependencies": {
     "http-server": "^14.1.1"
+  },
+  "dependencies": {
+    "appwrite": "^18.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- replace CDN import with npm-installed Appwrite SDK
- add Appwrite 18.1.1 to dependencies

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6853596943448327b660604becf67686