### PR TITLE
Add dotenv support and env file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is a very small prototype web application that demonstrates how to exchange
 - Ionic UI components loaded from a CDN
 
 All data is stored in Appwrite Authentication, Databases and Storage.
-Copy `env.example.js` to `env.js` and fill in your Appwrite credentials.
-The application imports these values from `env.js` at runtime.
+Copy `.env.example` to `.env` and fill in your Appwrite credentials.
+When `npm start` runs, a small script uses these values to generate
+`env.js` which the application imports at runtime.
 The UI relies on Ionic's CDN so you need an internet connection when opening `index.html` in a web browser.
 
 ## Local Development

--- a/generate-env.js
+++ b/generate-env.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load variables from .env if present
+dotenv.config();
+
+const output = `export default {
+  APPWRITE_ENDPOINT: '${process.env.APPWRITE_ENDPOINT || ''}',
+  APPWRITE_PROJECT_ID: '${process.env.APPWRITE_PROJECT_ID || ''}',
+  APPWRITE_DATABASE_ID: '${process.env.APPWRITE_DATABASE_ID || ''}',
+  APPWRITE_POSTS_COLLECTION_ID: '${process.env.APPWRITE_POSTS_COLLECTION_ID || ''}',
+  APPWRITE_BUCKET_ID: '${process.env.APPWRITE_BUCKET_ID || ''}'
+};\n`;
+
+fs.writeFileSync(path.join(__dirname, 'env.js'), output);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "appwrite": "^18.1.1"
+        "appwrite": "^18.1.1",
+        "dotenv": "^16.5.0"
       },
       "devDependencies": {
         "http-server": "^14.1.1"
@@ -151,6 +152,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "start": "http-server -p 8000",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prestart": "node generate-env.js"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +16,7 @@
     "http-server": "^14.1.1"
   },
   "dependencies": {
-    "appwrite": "^18.1.1"
+    "appwrite": "^18.1.1",
+    "dotenv": "^16.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- use `.env` file values and generate `env.js`
- integrate dotenv and prestart script
- document the env generation process

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68535e55df8c8327aaa4011d365da277